### PR TITLE
Gzip import in pyOFM.py

### DIFF
--- a/python/pyOFM.py
+++ b/python/pyOFM.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import numpy as np
 from mpi4py import MPI
+import gzip
 from .pyOFMesh import pyOFMesh
 try:
     from collections import OrderedDict


### PR DESCRIPTION
## Purpose
Gzip is not imported, which throws an error when `gzip.open()` is called.

## Type of change
Bugfix
