### PR TITLE
change argList to class variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 
 ._*
 .DS_Store
+.vscode
+build
+pyofm.egg-info
+__pycache__
+*.so
+pyOFMesh.cpp

--- a/src/OFMesh.C
+++ b/src/OFMesh.C
@@ -15,7 +15,8 @@ namespace Foam
 OFMesh::OFMesh(
     char* argsAll)
     : meshPtr_(nullptr),
-      runTimePtr_(nullptr)
+      runTimePtr_(nullptr),
+      argsPtr_(nullptr)
 {
     argsAll_ = argsAll;
 }

--- a/src/OFMesh.H
+++ b/src/OFMesh.H
@@ -35,6 +35,8 @@ private:
     /// all the arguments
     char* argsAll_;
 
+    autoPtr<argList> argsPtr_;
+
     autoPtr<fvMesh> meshPtr_;
 
     autoPtr<Time> runTimePtr_;

--- a/src/setRootCasePython.H
+++ b/src/setRootCasePython.H
@@ -15,7 +15,9 @@
 Foam::argList::addBoolOption("python", "Use Python/Cython wrapping such that the UPstream function \
     in OpenFOAM will not initialize or finalize MPI, instead, mpi4py will do that.");
 
-Foam::argList args(argc, argv, true, true, false);
+argsPtr_.reset(new Foam::argList(argc, argv, true, true, false));
+
+Foam::argList &args = argsPtr_();
 if (!args.checkRootCase())
 {
     Foam::FatalError.exit();


### PR DESCRIPTION
## Purpose
When OpenFOAM is compiled in “debug" mode, PYOFM can't destroy object correctly.
## Type of change
change argList to class variable


